### PR TITLE
Fix bug with unchecking radio when click on checked one

### DIFF
--- a/js/ion.checkRadio.js
+++ b/js/ion.checkRadio.js
@@ -107,7 +107,7 @@
                 var bindEvents = function(){
                     $elem.on("click", function(){
                         if(!disabled) {
-                            if(checked) {
+                            if(checked && type !== 'radio') {
                                 checkOff();
                             } else {
                                 checkOn();


### PR DESCRIPTION
Here a fix of bug: when you click on checked radio it become unchecked - default radio doesn't work like that.
