### PR TITLE
Make it compatible with Rails form builder

### DIFF
--- a/js/ion.checkRadio.js
+++ b/js/ion.checkRadio.js
@@ -69,7 +69,6 @@
                     if ($label.length > 0) {
                         $label.after(hidden);
                         $container = $("#icr-container__" + self.plugin_count);
-                        $input.appendTo($container);
                         $label.appendTo($container);
 
                         text = $label.html();


### PR DESCRIPTION
Make the rendered form compatible with Rails form builder, when Rails render a checkbox:

```
<label id='remember-me'>
   <%= f.check_box :remember_me %>
   <%= Spree.t(:remember_me) %>
</label>
```

it will put a hidden input before the checkbox, like

```
<label id='remember-me'>
  <input name="spree_user[remember_me]" type="hidden" value="0" />
  <input id="spree_user_remember_me" name="spree_user[remember_me]" type="checkbox" value="1" />
  Remember me
</label>
```

So if the user didn't check the checkbox, it will send the hidden '0' to the server. The order of the hidden and checkbox inputs
must be preserved. If we call 

```
$input.appendTo($container);
$label.appendTo($container);
```

The hidden input will be after the checkbox, then when the server receives the params, the value will always be 0. So remove the line

```
$input.appendTo($container);
```

to preserve the order of these two inputs.
